### PR TITLE
Fix: Specify ROS domain ID in shell script

### DIFF
--- a/servo_publisher/run_agent.sh
+++ b/servo_publisher/run_agent.sh
@@ -3,6 +3,7 @@
 echo "Starting micro-ROS Agent on UDP port 8888..."
 
 docker run -it --rm \
+  -e ROS_DOMAIN_ID=0 \
   -p 8888:8888/udp \
   microros/micro-ros-agent:humble \
   udp4 --port 8888 -v6

--- a/servo_publisher/run_publisher.sh
+++ b/servo_publisher/run_publisher.sh
@@ -7,6 +7,7 @@ CONTAINER_CODE_DIR="/workspaces/src/servo_publisher"
 
 docker run -it --rm \
   --network host \
+  -e ROS_DOMAIN_ID=0 \
   -v "${HOST_CODE_DIR}:${CONTAINER_CODE_DIR}" \
   -w "${CONTAINER_CODE_DIR}" \
   "${IMAGE}" \


### PR DESCRIPTION
We have to ensure that the 2 docker containers, trajectory publisher and Micro-ROS agent, are run on same ROS_DOMAIN_ID.